### PR TITLE
feat: Overview page — organic glass dashboard from design

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,66 +1,100 @@
-import Link from "next/link";
 import { AppShell } from "@/components/shell/app-shell";
-import { LiveMetricCard } from "@/components/ui/live-metric-card";
-import { StaggerContainer } from "@/components/ui/stagger-container";
-import { ActivityFeed, type ActivityItem } from "@/components/ui/activity-feed";
-import { demoAllocationReviewQueue, demoCashReconciliations, getFeaturedCashReconciliationHref, summarizeAllocationQueue, summarizeCashReconciliations } from "@/lib/demo/accounting-operations";
-
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
-
-const recentActivity: ActivityItem[] = [
-  { id: 1, time: "2 min ago", actor: "Controller", action: "approved allocation override for Cost of Goods — Cultivation", color: "var(--success)" },
-  { id: 2, time: "8 min ago", actor: "System", action: "flagged cash vault variance ($1,240) for Oakland location", color: "var(--warning)" },
-  { id: 3, time: "15 min ago", actor: "Reviewer", action: "signed off on reconciliation for Sacramento drawer", color: "var(--brand)" },
-  { id: 4, time: "23 min ago", actor: "System", action: "imported 842 transactions from bank feed (Mercury)", color: "var(--info)" },
-  { id: 5, time: "1 hr ago", actor: "Controller", action: "locked reporting period for March 2026", color: "var(--violet)" },
-];
+import { CloseHero } from "@/components/overview/close-hero";
+import { KpiRow } from "@/components/overview/kpi-row";
+import { ExposurePanel } from "@/components/overview/exposure-panel";
+import { CashLane } from "@/components/overview/cash-lane";
+import { ActionQueue } from "@/components/overview/action-queue";
+import { VarianceCard, FilingsCard, PipelineCard, ActivityCard } from "@/components/overview/right-rail";
 
 export default function DashboardPage() {
-  const allocationSummary = summarizeAllocationQueue(demoAllocationReviewQueue);
-  const reconciliationSummary = summarizeCashReconciliations(demoCashReconciliations);
-  const featuredReconciliationHref = getFeaturedCashReconciliationHref(demoCashReconciliations);
-
   return (
     <AppShell
       title="Overview"
-      description="Phase 1 dashboard for accounting/compliance MVP: close period status, 280E exceptions, reconciliation health, and filing deadlines."
+      description="Everything you need to move from intake to trusted CPA handoff."
     >
-      <StaggerContainer className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <LiveMetricCard label="Allocation queue" value={allocationSummary.ready + allocationSummary.needsSupport + allocationSummary.pendingController} detail={`${allocationSummary.approved} items already approved`} />
-        <LiveMetricCard label="Unreconciled cash" value={reconciliationSummary.absoluteVariance} detail={`${reconciliationSummary.investigating + reconciliationSummary.exception} cash workspaces need follow-up`} prefix="$" />
-        <LiveMetricCard label="Inventory drift" value={3.1} detail="Book vs package-level movement mismatch" suffix="%" decimals={1} />
-        <LiveMetricCard label="Upcoming filings" value={2} detail="California excise + sales tax due in 9 days" />
-      </StaggerContainer>
-
-      <div className="mt-6 grid gap-4 xl:grid-cols-3">
-        <Link href="/dashboard/allocations/history" className="rounded-2xl border border-border bg-surface-mid px-5 py-4 transition hover:bg-surface/70">
-          <div className="text-xs uppercase tracking-[0.2em] text-accent">New workspace</div>
-          <div className="mt-2 font-medium">Allocation override history</div>
-          <div className="mt-2 text-sm text-text-muted">Audit trail view of recommendations, overrides, evidence, and policy trail.</div>
-        </Link>
-        <Link href={featuredReconciliationHref} className="rounded-2xl border border-border bg-surface-mid px-5 py-4 transition hover:bg-surface/70">
-          <div className="text-xs uppercase tracking-[0.2em] text-accent">New detail</div>
-          <div className="mt-2 font-medium">Reconciliation drill-down</div>
-          <div className="mt-2 text-sm text-text-muted">Controller-style detail page with source breakdown, variance drivers, and next steps.</div>
-        </Link>
-        <Link href="/dashboard/exports" className="rounded-2xl border border-violet-500/20 bg-violet-500/10 px-5 py-4 transition hover:bg-violet-500/20">
-          <div className="text-xs uppercase tracking-[0.2em] text-violet-200">New handoff</div>
-          <div className="mt-2 font-medium text-violet-100">CPA export center</div>
-          <div className="mt-2 text-sm text-violet-100/80">Build demo-backed close packets, included schedules, and handoff checklist history.</div>
-        </Link>
+      {/* Phase label + system status */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 20,
+          marginTop: -8,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 10,
+            textTransform: "uppercase",
+            letterSpacing: "0.22em",
+            color: "var(--resin)",
+            fontWeight: 600,
+          }}
+        >
+          Phase 1 · Command
+        </span>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "7px 12px",
+            background: "var(--surface-raised)",
+            border: "1px solid var(--border)",
+            borderRadius: 999,
+            fontSize: 11.5,
+          }}
+        >
+          <span
+            className="dot-live"
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: "var(--mint)",
+              boxShadow: "0 0 8px var(--mint-glow)",
+              display: "inline-block",
+            }}
+          />
+          <span style={{ color: "var(--text-secondary)" }}>All systems nominal</span>
+          <span
+            style={{
+              width: 3,
+              height: 3,
+              borderRadius: 999,
+              background: "var(--text-faint)",
+              display: "inline-block",
+            }}
+          />
+          <span className="mono" style={{ color: "var(--text-muted)", fontSize: 10.5 }}>
+            Synced 2m ago
+          </span>
+        </div>
       </div>
 
-      <section className="mt-6 rounded-2xl border border-border bg-surface-mid p-5">
-        <div className="text-xs uppercase tracking-[0.2em] text-accent">Recent activity</div>
-        <p className="mt-2 text-sm text-text-muted">Latest audit trail events across the accounting workspace.</p>
-        <div className="mt-4">
-          <ActivityFeed items={recentActivity} maxItems={5} />
+      {/* Main content stack */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+        <CloseHero />
+        <KpiRow />
+
+        {/* Two-column grid: main panels + right rail */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 340px", gap: 14 }}>
+          {/* Left column */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+            <ExposurePanel />
+            <CashLane />
+            <ActionQueue />
+          </div>
+
+          {/* Right rail */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+            <VarianceCard />
+            <FilingsCard />
+            <PipelineCard />
+            <ActivityCard />
+          </div>
         </div>
-      </section>
+      </div>
     </AppShell>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -61,6 +61,43 @@
   --duration-fast: 150ms;
   --duration-normal: 250ms;
   --duration-slow: 400ms;
+
+  /* ── Overview page: Organic Glass palette ─────────────────────────── */
+  /* Mint — electric green for overview accents */
+  --mint: #48C072;
+  --mint-bright: #62D989;
+  --mint-deep: #1F6A3E;
+  --mint-dormant: #0E3420;
+  --mint-glow: rgba(72, 192, 114, 0.42);
+  --mint-soft: rgba(72, 192, 114, 0.14);
+
+  /* Resin — warm amber for blockers, not harsh red */
+  --resin: #F2B147;
+  --resin-bright: #FFC968;
+  --resin-glow: rgba(242, 177, 71, 0.38);
+  --resin-soft: rgba(242, 177, 71, 0.14);
+
+  /* Fibonacci radii for river-stone panels */
+  --r-1: 8px;
+  --r-2: 13px;
+  --r-3: 21px;
+  --r-5: 34px;
+  --r-8: 55px;
+
+  /* Hover easing */
+  --ease-calm: cubic-bezier(0.23, 1, 0.32, 1);
+  --t-hover: 420ms;
+
+  /* Section hues — per-panel color identity */
+  --hue-close:    #48C072;
+  --hue-kpis:     #5FC8A0;
+  --hue-280e:     #7ACF78;
+  --hue-cash:     #9CCF6A;
+  --hue-action:   #F2B147;
+  --hue-variance: #E5A850;
+  --hue-filings:  #8FB8D4;
+  --hue-pipeline: #6BC894;
+  --hue-activity: #A8B89E;
 }
 
 /* ─── BASE STYLES ──────────────────────────────────────────────────── */
@@ -181,6 +218,120 @@ a {
     transform: scaleX(1);
   }
 }
+
+/* ── Organic Glass animations (Overview page) ───────────────────────── */
+
+@keyframes breathe-mint {
+  0%, 100% {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.05),
+      0 0 24px rgba(72, 192, 114, 0.15),
+      0 12px 40px rgba(0, 0, 0, 0.35);
+    filter: brightness(1);
+  }
+  50% {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 0 52px rgba(72, 192, 114, 0.40),
+      0 12px 40px rgba(0, 0, 0, 0.35);
+    filter: brightness(1.06);
+  }
+}
+
+@keyframes breathe-resin {
+  0%, 100% {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.05),
+      0 0 24px rgba(242, 177, 71, 0.22),
+      0 12px 40px rgba(0, 0, 0, 0.35);
+  }
+  50% {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 0 52px rgba(242, 177, 71, 0.48),
+      0 12px 40px rgba(0, 0, 0, 0.35);
+  }
+}
+
+@keyframes dot-breathe {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(1.25); }
+}
+
+/* ── Glass panel base class ─────────────────────────────────────────── */
+
+.glass {
+  position: relative;
+  background: var(--surface);
+  backdrop-filter: blur(24px) saturate(1.3);
+  -webkit-backdrop-filter: blur(24px) saturate(1.3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+  overflow: hidden;
+  transition:
+    transform var(--t-hover) var(--ease-calm),
+    box-shadow var(--t-hover) var(--ease-calm),
+    border-color var(--t-hover) var(--ease-calm);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 12px 40px rgba(0, 0, 0, 0.35),
+    0 2px 8px rgba(0, 0, 0, 0.25);
+  will-change: transform;
+}
+
+.glass::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.06) 0%,
+      rgba(255, 255, 255, 0.01) 30%,
+      transparent 60%
+    ),
+    radial-gradient(ellipse at 0% 0%, rgba(72, 192, 114, 0.08), transparent 50%);
+  pointer-events: none;
+  opacity: 0.9;
+  transition: opacity var(--t-hover) var(--ease-calm);
+}
+
+.glass::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  background:
+    radial-gradient(circle at 30% 40%, rgba(255,255,255,0.08), transparent 6%),
+    radial-gradient(circle at 70% 60%, rgba(255,255,255,0.06), transparent 5%),
+    radial-gradient(circle at 50% 20%, rgba(255,255,255,0.05), transparent 4%);
+  transition: opacity var(--t-hover) var(--ease-calm);
+}
+
+.glass:hover {
+  transform: translateY(-3px);
+  border-color: rgba(120, 200, 160, 0.28);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 24px 60px rgba(0, 0, 0, 0.45),
+    0 8px 20px rgba(0, 0, 0, 0.30),
+    0 0 40px rgba(72, 192, 114, 0.08);
+}
+
+.glass:hover::before { opacity: 1; }
+.glass:hover::after  { opacity: 0.6; }
+
+.glass-deep {
+  border-radius: var(--r-5);
+}
+.glass-deep:hover { transform: translateY(-4px); }
+
+.breathe      { animation: breathe-mint  5.5s ease-in-out infinite; }
+.breathe-resin{ animation: breathe-resin 3.2s ease-in-out infinite; }
+.dot-live     { animation: dot-breathe   2.4s ease-in-out infinite; }
 
 @layer utilities {
   .text-balance {

--- a/src/components/overview/action-queue.tsx
+++ b/src/components/overview/action-queue.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import { ACTION_QUEUE, fmtK, type ActionKind } from "@/lib/demo/overview-data";
+import { GlassCard, GlassPill } from "./glass-card";
+
+type Filter = "all" | ActionKind;
+const FILTERS: Filter[] = ["all", "Allocation", "Rec", "Filing"];
+
+export function ActionQueue() {
+  const [filter, setFilter] = useState<Filter>("all");
+  const items = filter === "all" ? ACTION_QUEUE : ACTION_QUEUE.filter((i) => i.kind === filter);
+  const criticalCount = ACTION_QUEUE.filter((i) => i.severity === "critical").length;
+
+  return (
+    <GlassCard
+      hue="var(--hue-action)"
+      title="Action queue"
+      subtitle={
+        <span>
+          {ACTION_QUEUE.length} items ·{" "}
+          <span style={{ color: "var(--danger)" }}>{criticalCount} critical</span>
+        </span>
+      }
+      right={
+        <div
+          style={{
+            display: "flex",
+            gap: 4,
+            padding: 3,
+            background: "var(--surface-raised)",
+            borderRadius: 8,
+            border: "1px solid var(--border-subtle)",
+          }}
+        >
+          {FILTERS.map((f) => (
+            <button
+              key={f}
+              onClick={() => setFilter(f)}
+              style={{
+                padding: "4px 10px",
+                borderRadius: 5,
+                background: filter === f ? "var(--surface-overlay)" : "transparent",
+                color: filter === f ? "var(--text-primary)" : "var(--text-muted)",
+                border: "none",
+                fontSize: 11,
+                fontWeight: 500,
+                cursor: "pointer",
+                textTransform: "capitalize",
+              }}
+            >
+              {f}
+            </button>
+          ))}
+        </div>
+      }
+    >
+      <div>
+        {items.map((item, i) => {
+          const tone =
+            item.severity === "critical" ? "danger" : item.severity === "high" ? "warning" : "neutral";
+          const borderColor =
+            item.severity === "critical"
+              ? "var(--danger)"
+              : item.severity === "high"
+              ? "var(--resin)"
+              : "var(--border-subtle)";
+
+          return (
+            <div
+              key={item.id}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "3px 90px 1fr auto auto",
+                gap: 14,
+                alignItems: "center",
+                padding: "11px 0",
+                borderBottom: i < items.length - 1 ? "1px solid var(--border-subtle)" : "none",
+              }}
+            >
+              {/* severity bar */}
+              <div style={{ width: 3, height: 28, background: borderColor, borderRadius: 2 }} />
+
+              {/* pill + kind */}
+              <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+                <GlassPill tone={tone} size="sm">{item.severity}</GlassPill>
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: "var(--text-faint)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.1em",
+                    paddingLeft: 2,
+                  }}
+                >
+                  {item.kind}
+                </span>
+              </div>
+
+              {/* title + detail */}
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 12.5, color: "var(--text-primary)", fontWeight: 500, marginBottom: 2 }}>
+                  {item.title}
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: "var(--text-muted)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {item.detail}
+                </div>
+              </div>
+
+              {/* owner + due */}
+              <div style={{ textAlign: "right", fontSize: 10.5, color: "var(--text-muted)" }}>
+                <div style={{ fontWeight: 500 }}>{item.owner}</div>
+                <div
+                  className="mono"
+                  style={{
+                    color: item.due === "Today" ? "var(--resin)" : "var(--text-faint)",
+                    marginTop: 2,
+                  }}
+                >
+                  {item.due}
+                </div>
+              </div>
+
+              {/* amount */}
+              <div style={{ textAlign: "right", minWidth: 70 }}>
+                <div
+                  className="mono"
+                  style={{
+                    fontSize: 12,
+                    fontWeight: 600,
+                    color: item.amount < 0 ? "var(--resin)" : "var(--text-primary)",
+                  }}
+                >
+                  {fmtK(Math.abs(item.amount))}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </GlassCard>
+  );
+}

--- a/src/components/overview/cash-lane.tsx
+++ b/src/components/overview/cash-lane.tsx
@@ -1,0 +1,111 @@
+import { CASH_RECS, fmtUSD, type RecStatus } from "@/lib/demo/overview-data";
+import { GlassCard, GlassPill } from "./glass-card";
+import type { CSSProperties } from "react";
+
+type PillTone = "success" | "warning" | "danger" | "info";
+
+const STATUS_CONFIG: Record<RecStatus, { label: string; tone: PillTone }> = {
+  balanced:       { label: "Balanced",      tone: "success" },
+  investigating:  { label: "Investigating", tone: "warning" },
+  exception:      { label: "Exception",     tone: "danger"  },
+  ready_to_post:  { label: "Ready to post", tone: "info"    },
+};
+
+export function CashLane() {
+  return (
+    <GlassCard
+      hue="var(--hue-cash)"
+      title="Cash reconciliations"
+      subtitle="Oakland Flagship · April 2026"
+      right={
+        <a href="/dashboard/reconciliations" style={{ fontSize: 11.5, color: "var(--text-muted)", textDecoration: "none" }}>
+          All 4 workspaces →
+        </a>
+      }
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 10 }}>
+        {CASH_RECS.map((rec) => {
+          const st = STATUS_CONFIG[rec.status];
+          const isBalanced = rec.variance === 0;
+          const shortName = rec.loc.split(" — ")[1];
+          const typeLabel = rec.type.replace("_", " ");
+
+          return (
+            <div
+              key={rec.id}
+              className="glass"
+              style={{
+                background: "var(--surface-raised)",
+                border: "1px solid var(--border)",
+                borderRadius: 10,
+                padding: 12,
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 6 }}>
+                <div style={{ fontSize: 11.5, fontWeight: 500, color: "var(--text-primary)", lineHeight: 1.3 }}>
+                  {shortName}
+                </div>
+                <GlassPill tone={st.tone} size="sm">{st.label}</GlassPill>
+              </div>
+              <div
+                style={{
+                  fontSize: 10.5,
+                  color: "var(--text-faint)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.15em",
+                }}
+              >
+                {typeLabel}
+              </div>
+              <div style={{ borderTop: "1px solid var(--border-subtle)", paddingTop: 8 }}>
+                <Row label="Expected" value={fmtUSD(rec.expected, 2)} />
+                <Row label="Counted"  value={fmtUSD(rec.actual, 2)} />
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    marginTop: 6,
+                    paddingTop: 6,
+                    borderTop: "1px dashed var(--border-subtle)",
+                  }}
+                >
+                  <span style={{ fontSize: 10.5, color: "var(--text-secondary)", fontWeight: 500 }}>Variance</span>
+                  <span
+                    className="mono"
+                    style={{
+                      fontSize: 12.5,
+                      fontWeight: 600,
+                      color: isBalanced ? "var(--mint)" : "var(--resin)",
+                    }}
+                  >
+                    {isBalanced ? "±0.00" : fmtUSD(rec.variance, 2)}
+                  </span>
+                </div>
+              </div>
+              <div style={{ fontSize: 10, color: "var(--text-faint)" }}>Owner · {rec.owner}</div>
+            </div>
+          );
+        })}
+      </div>
+    </GlassCard>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  const s: CSSProperties = {
+    display: "flex",
+    justifyContent: "space-between",
+    fontSize: 10.5,
+    color: "var(--text-muted)",
+    marginTop: 2,
+  };
+  return (
+    <div style={s}>
+      <span>{label}</span>
+      <span className="mono">{value}</span>
+    </div>
+  );
+}

--- a/src/components/overview/charts.tsx
+++ b/src/components/overview/charts.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import type { AllocationTrendPoint, VariancePoint, PipelineStage } from "@/lib/demo/overview-data";
+
+// ── Sparkline ────────────────────────────────────────────────────────────────
+
+export function Sparkline({
+  data,
+  color = "var(--brand)",
+  width = 120,
+  height = 32,
+  fill = true,
+}: {
+  data: number[];
+  color?: string;
+  width?: number;
+  height?: number;
+  fill?: boolean;
+}) {
+  if (!data || data.length === 0) return null;
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const step = width / (data.length - 1 || 1);
+  const points = data.map((v, i): [number, number] => [
+    i * step,
+    height - ((v - min) / range) * (height - 4) - 2,
+  ]);
+  const path = points.map((p, i) => (i === 0 ? `M${p[0]},${p[1]}` : `L${p[0]},${p[1]}`)).join(" ");
+  const areaPath = `${path} L${points[points.length - 1][0]},${height} L0,${height} Z`;
+  const id = "sg_" + Math.random().toString(36).slice(2, 9);
+  return (
+    <svg width={width} height={height} style={{ display: "block" }}>
+      <defs>
+        <linearGradient id={id} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity="0.35" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {fill && <path d={areaPath} fill={`url(#${id})`} />}
+      <path d={path} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      {points.map((p, i) =>
+        i === points.length - 1 ? (
+          <circle key={i} cx={p[0]} cy={p[1]} r="2.5" fill={color} stroke="var(--surface)" strokeWidth="1.5" />
+        ) : null
+      )}
+    </svg>
+  );
+}
+
+// ── Ring ─────────────────────────────────────────────────────────────────────
+
+export function Ring({
+  value,
+  size = 72,
+  stroke = 6,
+  color = "var(--brand)",
+  track = "var(--border)",
+  label,
+}: {
+  value: number;
+  size?: number;
+  stroke?: number;
+  color?: string;
+  track?: string;
+  label?: string;
+}) {
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  const offset = c * (1 - value);
+  return (
+    <div style={{ position: "relative", width: size, height: size }}>
+      <svg width={size} height={size} style={{ transform: "rotate(-90deg)" }}>
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke={track} strokeWidth={stroke} />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke={color}
+          strokeWidth={stroke}
+          strokeDasharray={c}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          style={{ transition: "stroke-dashoffset 600ms cubic-bezier(0.16,1,0.3,1)" }}
+        />
+      </svg>
+      <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center" }}>
+        <div
+          className="mono"
+          style={{ fontSize: size / 4.5, fontWeight: 600, letterSpacing: "-0.02em", textAlign: "center" }}
+        >
+          {label}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── StackedBarChart ───────────────────────────────────────────────────────────
+
+export function StackedBarChart({ data, height = 150 }: { data: AllocationTrendPoint[]; height?: number }) {
+  const max = Math.max(...data.map((d) => d.ded + d.non));
+  const barW = 28;
+  const gap = 28;
+  const width = data.length * (barW + gap) - gap + 40;
+  return (
+    <svg
+      width="100%"
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      style={{ overflow: "visible" }}
+    >
+      {[0.25, 0.5, 0.75, 1].map((t) => (
+        <line
+          key={t}
+          x1={0}
+          x2={width}
+          y1={height - t * (height - 30)}
+          y2={height - t * (height - 30)}
+          stroke="var(--border-subtle)"
+          strokeWidth="1"
+          strokeDasharray="2 4"
+        />
+      ))}
+      {data.map((d, i) => {
+        const x = 20 + i * (barW + gap);
+        const total = d.ded + d.non;
+        const totalH = (total / max) * (height - 30);
+        const dedH = (d.ded / total) * totalH;
+        const nonH = totalH - dedH;
+        const y = height - 20 - totalH;
+        const isLast = i === data.length - 1;
+        return (
+          <g key={d.m}>
+            <rect
+              x={x} y={y} width={barW} height={nonH}
+              fill={isLast ? "var(--resin)" : "rgba(242,177,71,0.45)"}
+              rx="2"
+            />
+            <rect
+              x={x} y={y + nonH} width={barW} height={dedH}
+              fill={isLast ? "var(--mint)" : "var(--mint-soft)"}
+              stroke={isLast ? "var(--mint)" : "rgba(72,192,114,0.4)"}
+              strokeWidth="1"
+              rx="2"
+            />
+            <text
+              x={x + barW / 2} y={height - 4}
+              textAnchor="middle"
+              fill="var(--text-muted)"
+              fontSize="10"
+              fontFamily="Inter"
+            >
+              {d.m}
+            </text>
+            {isLast && (
+              <text
+                x={x + barW / 2} y={y - 8}
+                textAnchor="middle"
+                fill="var(--text-primary)"
+                fontSize="10"
+                fontWeight="600"
+                fontFamily="JetBrains Mono, monospace"
+              >
+                {(total / 1000).toFixed(0)}k
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+// ── VarianceChart ─────────────────────────────────────────────────────────────
+
+export function VarianceChart({ data, height = 80 }: { data: VariancePoint[]; height?: number }) {
+  const max = Math.max(...data.map((d) => Math.abs(d.v)));
+  const barW = 18;
+  const gap = 16;
+  const width = data.length * (barW + gap);
+  return (
+    <svg width={width} height={height}>
+      <line x1="0" x2={width} y1={height / 2} y2={height / 2} stroke="var(--border)" strokeWidth="1" />
+      {data.map((d, i) => {
+        const x = i * (barW + gap);
+        const h = (Math.abs(d.v) / max) * (height / 2 - 14);
+        const y = d.v < 0 ? height / 2 : height / 2 - h;
+        const isLast = i === data.length - 1;
+        return (
+          <g key={d.m}>
+            <rect
+              x={x} y={y} width={barW} height={h}
+              fill={isLast ? "var(--resin)" : "rgba(242,177,71,0.4)"}
+              rx="2"
+            />
+            <text
+              x={x + barW / 2} y={height - 2}
+              textAnchor="middle"
+              fill="var(--text-faint)"
+              fontSize="9"
+              fontFamily="Inter"
+            >
+              {d.m}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+// ── FunnelChart ───────────────────────────────────────────────────────────────
+
+export function FunnelChart({ data }: { data: PipelineStage[] }) {
+  const max = data[0].count;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      {data.map((d, i) => {
+        const w = (d.count / max) * 100;
+        const next = data[i + 1];
+        const loss = next ? ((d.count - next.count) / d.count) * 100 : 0;
+        return (
+          <div key={d.stage} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <div style={{ width: 110, fontSize: 11.5, color: "var(--text-secondary)" }}>{d.stage}</div>
+            <div style={{ flex: 1, position: "relative", height: 22 }}>
+              <div
+                style={{
+                  width: `${w}%`,
+                  height: "100%",
+                  background: `linear-gradient(90deg, var(--mint-soft), rgba(72,192,114,${0.4 - i * 0.05}))`,
+                  border: "1px solid rgba(72,192,114,0.4)",
+                  borderRadius: 4,
+                  display: "flex",
+                  alignItems: "center",
+                  paddingLeft: 8,
+                }}
+              >
+                <span className="mono" style={{ fontSize: 10.5, fontWeight: 600, color: "var(--text-primary)" }}>
+                  {d.count}
+                </span>
+              </div>
+            </div>
+            <div className="mono" style={{ width: 60, textAlign: "right", fontSize: 10.5, color: "var(--text-muted)" }}>
+              {i > 0 ? `-${loss.toFixed(0)}%` : ""}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/overview/charts.tsx
+++ b/src/components/overview/charts.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import type { AllocationTrendPoint, VariancePoint, PipelineStage } from "@/lib/demo/overview-data";
 
 // ── Sparkline ────────────────────────────────────────────────────────────────
@@ -17,6 +18,8 @@ export function Sparkline({
   height?: number;
   fill?: boolean;
 }) {
+  const uid = useId();
+  const id = "sg_" + uid.replace(/:/g, "");
   if (!data || data.length === 0) return null;
   const max = Math.max(...data);
   const min = Math.min(...data);
@@ -28,7 +31,6 @@ export function Sparkline({
   ]);
   const path = points.map((p, i) => (i === 0 ? `M${p[0]},${p[1]}` : `L${p[0]},${p[1]}`)).join(" ");
   const areaPath = `${path} L${points[points.length - 1][0]},${height} L0,${height} Z`;
-  const id = "sg_" + Math.random().toString(36).slice(2, 9);
   return (
     <svg width={width} height={height} style={{ display: "block" }}>
       <defs>

--- a/src/components/overview/close-hero.tsx
+++ b/src/components/overview/close-hero.tsx
@@ -1,0 +1,208 @@
+import { CLOSE_DATA } from "@/lib/demo/overview-data";
+import { GlassPill } from "./glass-card";
+import { Ring } from "./charts";
+import Link from "next/link";
+
+export function CloseHero() {
+  const { period, dayOfClose, totalCloseDays, percentComplete, cpaHandoffTarget, daysToHandoff, milestones } =
+    CLOSE_DATA;
+
+  return (
+    <div
+      className="breathe"
+      style={{
+        background: `linear-gradient(135deg, color-mix(in oklch, var(--hue-close) 14%, var(--surface-raised)), var(--surface) 70%)`,
+        border: "1px solid color-mix(in oklch, var(--hue-close) 35%, var(--border))",
+        borderRadius: 18,
+        padding: 22,
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      {/* top accent bar */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0, left: 0, right: 0,
+          height: 2,
+          background: "linear-gradient(90deg, var(--hue-close), transparent 70%)",
+        }}
+      />
+      {/* ambient glow top-right */}
+      <div
+        style={{
+          position: "absolute", top: 0, right: 0, bottom: 0, width: 360,
+          background: "radial-gradient(ellipse at top right, color-mix(in oklch, var(--hue-close) 20%, transparent), transparent 70%)",
+          pointerEvents: "none",
+        }}
+      />
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr auto",
+          gap: 24,
+          alignItems: "center",
+          position: "relative",
+        }}
+      >
+        {/* left: info + milestones */}
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
+            <GlassPill tone="brand">Close in progress</GlassPill>
+            <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+              Period ·{" "}
+              <span className="mono" style={{ color: "var(--text-secondary)" }}>
+                {period}
+              </span>
+            </span>
+            <span style={{ width: 3, height: 3, borderRadius: 999, background: "var(--text-faint)", display: "inline-block" }} />
+            <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+              CPA handoff ·{" "}
+              <span className="mono" style={{ color: "var(--text-secondary)" }}>
+                {cpaHandoffTarget}
+              </span>
+            </span>
+          </div>
+
+          <div style={{ display: "flex", alignItems: "baseline", gap: 12, marginBottom: 16 }}>
+            <h2 style={{ margin: 0, fontSize: 30, fontWeight: 600, letterSpacing: "-0.02em" }}>
+              Day {dayOfClose} of {totalCloseDays}
+            </h2>
+            <span style={{ fontSize: 14, color: "var(--text-muted)" }}>
+              · {daysToHandoff} business days to a defensible packet
+            </span>
+          </div>
+
+          {/* milestone strip */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: `repeat(${milestones.length}, 1fr)`,
+              gap: 6,
+            }}
+          >
+            {milestones.map((ms) => (
+              <div key={ms.label}>
+                <div
+                  style={{
+                    height: 6,
+                    borderRadius: 3,
+                    background: "var(--border-subtle)",
+                    position: "relative",
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${ms.pct * 100}%`,
+                      height: "100%",
+                      background:
+                        ms.status === "complete"
+                          ? "var(--mint)"
+                          : ms.status === "active"
+                          ? "linear-gradient(90deg, var(--mint), var(--resin))"
+                          : "transparent",
+                      borderRadius: 3,
+                      transition: "width 600ms cubic-bezier(0.16,1,0.3,1)",
+                    }}
+                  />
+                  {ms.status === "active" && (
+                    <div
+                      style={{
+                        position: "absolute",
+                        top: 0,
+                        bottom: 0,
+                        left: `${ms.pct * 100}%`,
+                        width: 2,
+                        background: "var(--resin)",
+                        boxShadow: "0 0 8px var(--resin)",
+                      }}
+                    />
+                  )}
+                </div>
+                <div
+                  style={{
+                    marginTop: 8,
+                    fontSize: 10.5,
+                    color:
+                      ms.status === "pending"
+                        ? "var(--text-faint)"
+                        : ms.status === "active"
+                        ? "var(--resin)"
+                        : "var(--text-secondary)",
+                    fontWeight: ms.status === "active" ? 600 : 500,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 4,
+                  }}
+                >
+                  {ms.status === "complete" && (
+                    <span style={{ color: "var(--mint)" }}>✓</span>
+                  )}
+                  {ms.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* right: ring + CTAs */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 20,
+            paddingLeft: 24,
+            borderLeft: "1px solid var(--border-subtle)",
+          }}
+        >
+          <Ring
+            value={percentComplete}
+            size={96}
+            stroke={8}
+            color="var(--mint)"
+            label={`${Math.round(percentComplete * 100)}%`}
+          />
+          <div style={{ display: "flex", flexDirection: "column", gap: 10, minWidth: 170 }}>
+            <Link
+              href="/dashboard/accounting/close"
+              style={{
+                display: "block",
+                padding: "10px 14px",
+                borderRadius: 10,
+                background: "var(--mint)",
+                color: "#041007",
+                border: "none",
+                fontSize: 12.5,
+                fontWeight: 600,
+                textDecoration: "none",
+                textAlign: "center",
+                boxShadow: "0 2px 12px var(--mint-glow)",
+              }}
+            >
+              Resume close →
+            </Link>
+            <Link
+              href="/dashboard/exports"
+              style={{
+                display: "block",
+                padding: "10px 14px",
+                borderRadius: 10,
+                background: "transparent",
+                color: "var(--text-secondary)",
+                border: "1px solid var(--border)",
+                fontSize: 12.5,
+                fontWeight: 500,
+                textDecoration: "none",
+                textAlign: "center",
+              }}
+            >
+              Preview CPA packet
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/overview/exposure-panel.tsx
+++ b/src/components/overview/exposure-panel.tsx
@@ -1,0 +1,106 @@
+import { ALLOCATIONS, fmtK, fmtPct } from "@/lib/demo/overview-data";
+import { GlassCard, GlassPill } from "./glass-card";
+import { StackedBarChart } from "./charts";
+
+export function ExposurePanel() {
+  const curr = ALLOCATIONS.trend[ALLOCATIONS.trend.length - 1];
+  const total = curr.ded + curr.non;
+
+  return (
+    <GlassCard
+      hue="var(--hue-280e)"
+      title="280E Exposure"
+      subtitle={
+        <span style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          Deductible vs nondeductible spend
+          <GlassPill tone="brand" size="sm">Defensible</GlassPill>
+        </span>
+      }
+      right={
+        <div style={{ display: "flex", gap: 16, fontSize: 11 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: "var(--mint)", display: "inline-block" }} />
+            <span style={{ color: "var(--text-muted)" }}>Deductible</span>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: "var(--resin)", display: "inline-block" }} />
+            <span style={{ color: "var(--text-muted)" }}>Nondeductible</span>
+          </div>
+        </div>
+      }
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 220px", gap: 24 }}>
+        <StackedBarChart data={ALLOCATIONS.trend} height={180} />
+
+        <div
+          style={{
+            borderLeft: "1px solid var(--border-subtle)",
+            paddingLeft: 20,
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            justifyContent: "center",
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: 10,
+                textTransform: "uppercase",
+                letterSpacing: "0.18em",
+                color: "var(--text-faint)",
+                fontWeight: 600,
+              }}
+            >
+              Current period
+            </div>
+            <div className="mono" style={{ fontSize: 22, fontWeight: 600, marginTop: 4 }}>
+              {fmtK(total)}
+            </div>
+            <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>
+              {ALLOCATIONS.total} allocation items
+            </div>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            {/* Deductible bar */}
+            <div>
+              <div style={{ display: "flex", justifyContent: "space-between", fontSize: 11, marginBottom: 5 }}>
+                <span style={{ color: "var(--text-secondary)" }}>Deductible</span>
+                <span className="mono" style={{ color: "var(--text-primary)", fontWeight: 600 }}>
+                  {fmtK(curr.ded)}
+                </span>
+              </div>
+              <div style={{ height: 4, borderRadius: 2, background: "var(--border-subtle)", overflow: "hidden" }}>
+                <div
+                  style={{ width: `${(curr.ded / total) * 100}%`, height: "100%", background: "var(--mint)" }}
+                />
+              </div>
+              <div style={{ fontSize: 10, color: "var(--text-faint)", marginTop: 3 }}>
+                {fmtPct(curr.ded / total, 1)} of total
+              </div>
+            </div>
+
+            {/* Nondeductible bar */}
+            <div>
+              <div style={{ display: "flex", justifyContent: "space-between", fontSize: 11, marginBottom: 5 }}>
+                <span style={{ color: "var(--text-secondary)" }}>Nondeductible (280E)</span>
+                <span className="mono" style={{ color: "var(--text-primary)", fontWeight: 600 }}>
+                  {fmtK(curr.non)}
+                </span>
+              </div>
+              <div style={{ height: 4, borderRadius: 2, background: "var(--border-subtle)", overflow: "hidden" }}>
+                <div
+                  style={{ width: `${(curr.non / total) * 100}%`, height: "100%", background: "var(--resin)" }}
+                />
+              </div>
+              <div style={{ fontSize: 10, color: "var(--text-faint)", marginTop: 3 }}>
+                {fmtPct(curr.non / total, 1)} of total
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </GlassCard>
+  );
+}

--- a/src/components/overview/glass-card.tsx
+++ b/src/components/overview/glass-card.tsx
@@ -1,0 +1,147 @@
+import type { CSSProperties, ReactNode } from "react";
+
+// ── GlassPill ────────────────────────────────────────────────────────────────
+
+type PillTone = "neutral" | "brand" | "warning" | "danger" | "success" | "info" | "violet" | "accent";
+
+const PILL_TONES: Record<PillTone, { bg: string; fg: string; bd: string }> = {
+  neutral: { bg: "var(--surface-overlay)",  fg: "var(--text-secondary)", bd: "var(--border)"              },
+  brand:   { bg: "var(--mint-soft)",         fg: "var(--mint)",           bd: "rgba(72,192,114,0.3)"       },
+  warning: { bg: "var(--resin-soft)",        fg: "var(--resin)",          bd: "rgba(242,177,71,0.3)"       },
+  danger:  { bg: "var(--danger-soft)",       fg: "var(--danger)",         bd: "rgba(239,68,68,0.3)"        },
+  success: { bg: "var(--success-soft)",      fg: "var(--success)",        bd: "rgba(34,197,94,0.3)"        },
+  info:    { bg: "var(--info-soft)",         fg: "var(--info)",           bd: "rgba(59,130,246,0.3)"       },
+  violet:  { bg: "var(--violet-soft)",       fg: "var(--violet)",         bd: "rgba(139,92,246,0.3)"       },
+  accent:  { bg: "var(--accent-soft)",       fg: "var(--accent)",         bd: "rgba(212,146,42,0.3)"       },
+};
+
+export function GlassPill({
+  children,
+  tone = "neutral",
+  size = "md",
+}: {
+  children: ReactNode;
+  tone?: PillTone;
+  size?: "sm" | "md";
+}) {
+  const t = PILL_TONES[tone];
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding: size === "sm" ? "1px 6px" : "2px 8px",
+        borderRadius: 999,
+        background: t.bg,
+        color: t.fg,
+        border: `1px solid ${t.bd}`,
+        fontSize: size === "sm" ? 9.5 : 10.5,
+        fontWeight: 600,
+        letterSpacing: "0.02em",
+        textTransform: "uppercase" as const,
+        whiteSpace: "nowrap" as const,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+// ── GlassCard ────────────────────────────────────────────────────────────────
+
+export function GlassCard({
+  title,
+  subtitle,
+  right,
+  children,
+  hue,
+  padding = 18,
+  breathe = false,
+  className = "",
+  style,
+}: {
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  right?: ReactNode;
+  children: ReactNode;
+  hue?: string;
+  padding?: number;
+  breathe?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  const tintBg = hue
+    ? `linear-gradient(180deg, color-mix(in oklch, ${hue} 7%, var(--surface)), var(--surface) 60%)`
+    : "var(--surface)";
+  const tintBorder = hue ? `color-mix(in oklch, ${hue} 28%, var(--border))` : "var(--border)";
+
+  return (
+    <div
+      className={`glass${breathe ? " breathe" : ""} ${className}`.trim()}
+      style={{
+        background: tintBg,
+        border: `1px solid ${tintBorder}`,
+        borderRadius: 14,
+        padding,
+        position: "relative",
+        overflow: "hidden",
+        ...style,
+      }}
+    >
+      {hue && (
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 2,
+            background: `linear-gradient(90deg, ${hue}, transparent 80%)`,
+          }}
+        />
+      )}
+      {(title || right) && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            marginBottom: 14,
+            gap: 10,
+          }}
+        >
+          <div style={{ minWidth: 0 }}>
+            {title && (
+              <div
+                style={{
+                  fontSize: 10,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.2em",
+                  color: "var(--text-faint)",
+                  fontWeight: 600,
+                }}
+              >
+                {title}
+              </div>
+            )}
+            {subtitle && (
+              <div
+                style={{
+                  fontSize: 13.5,
+                  color: "var(--text-primary)",
+                  fontWeight: 500,
+                  marginTop: 6,
+                }}
+              >
+                {subtitle}
+              </div>
+            )}
+          </div>
+          {right}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/components/overview/kpi-row.tsx
+++ b/src/components/overview/kpi-row.tsx
@@ -1,0 +1,146 @@
+import { ALLOCATIONS, fmtUSD, fmtK, fmtPct } from "@/lib/demo/overview-data";
+import { Sparkline } from "./charts";
+
+type Delta = { positive: boolean; value: string };
+
+function KpiTile({
+  label,
+  value,
+  suffix,
+  sub,
+  delta,
+  trend,
+  accent,
+  hue,
+}: {
+  label: string;
+  value: string | number;
+  suffix?: string;
+  sub: string;
+  delta?: Delta;
+  trend?: number[];
+  accent?: string;
+  hue?: string;
+}) {
+  const tintBg = hue
+    ? `linear-gradient(180deg, color-mix(in oklch, ${hue} 8%, var(--surface)), var(--surface) 65%)`
+    : "var(--surface)";
+  const tintBorder = hue ? `color-mix(in oklch, ${hue} 30%, var(--border))` : "var(--border)";
+
+  return (
+    <div
+      className="glass"
+      style={{
+        background: tintBg,
+        border: `1px solid ${tintBorder}`,
+        borderRadius: 14,
+        padding: 16,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        minHeight: 132,
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      {hue && (
+        <div
+          style={{
+            position: "absolute",
+            top: 0, left: 0, right: 0,
+            height: 2,
+            background: `linear-gradient(90deg, ${hue}, transparent 80%)`,
+          }}
+        />
+      )}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+        <div
+          style={{
+            fontSize: 10.5,
+            textTransform: "uppercase",
+            letterSpacing: "0.18em",
+            color: "var(--text-faint)",
+            fontWeight: 600,
+          }}
+        >
+          {label}
+        </div>
+        {delta && (
+          <span
+            className="mono"
+            style={{
+              fontSize: 10.5,
+              fontWeight: 600,
+              color: delta.positive ? "var(--mint)" : "var(--resin)",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 3,
+            }}
+          >
+            {delta.positive ? "▲" : "▼"} {delta.value}
+          </span>
+        )}
+      </div>
+      <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
+        <div
+          className="mono"
+          style={{ fontSize: 26, fontWeight: 600, letterSpacing: "-0.02em", color: "var(--text-primary)" }}
+        >
+          {value}
+        </div>
+        {suffix && <span style={{ fontSize: 12, color: "var(--text-muted)" }}>{suffix}</span>}
+      </div>
+      <div style={{ fontSize: 11.5, color: "var(--text-muted)" }}>{sub}</div>
+      <div style={{ marginTop: "auto", height: 32 }}>
+        {trend && <Sparkline data={trend} color={accent ?? "var(--mint)"} width={220} height={32} />}
+      </div>
+    </div>
+  );
+}
+
+export function KpiRow() {
+  const inQueue = ALLOCATIONS.ready + ALLOCATIONS.needsSupport + ALLOCATIONS.pendingController;
+  const total = ALLOCATIONS.deductible + ALLOCATIONS.nondeductible;
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12 }}>
+      <KpiTile
+        hue="var(--hue-kpis)"
+        label="Allocation queue"
+        value={inQueue}
+        suffix={`/ ${ALLOCATIONS.total}`}
+        sub={`${ALLOCATIONS.approved} approved · ${ALLOCATIONS.needsSupport} need support`}
+        delta={{ positive: false, value: "+3 vs Mar" }}
+        trend={[22, 28, 25, 31, 27, 33]}
+        accent="var(--mint)"
+      />
+      <KpiTile
+        hue="var(--hue-280e)"
+        label="Unreconciled cash"
+        value={fmtUSD(146)}
+        sub="2 workspaces in follow-up · 2 ready"
+        delta={{ positive: true, value: "33% vs Mar" }}
+        trend={[420, 380, 520, 290, 320, 146]}
+        accent="var(--resin)"
+      />
+      <KpiTile
+        hue="var(--hue-cash)"
+        label="280E exposure"
+        value={fmtK(ALLOCATIONS.nondeductible)}
+        sub={`${fmtPct(ALLOCATIONS.nondeductible / total, 1)} of total spend this period`}
+        delta={{ positive: false, value: "+5.2%" }}
+        trend={ALLOCATIONS.trend.map((t) => t.non)}
+        accent="var(--resin)"
+      />
+      <KpiTile
+        hue="var(--hue-action)"
+        label="Filings due"
+        value="2"
+        suffix="· 9d"
+        sub="CA excise Apr 30 · sales & use May 2"
+        trend={[2, 2, 3, 2, 2, 2]}
+        accent="var(--info)"
+      />
+    </div>
+  );
+}

--- a/src/components/overview/right-rail.tsx
+++ b/src/components/overview/right-rail.tsx
@@ -1,0 +1,173 @@
+import { VARIANCE_TREND, FILINGS, PIPELINE, ACTIVITY, fmtK, type ActivityTag } from "@/lib/demo/overview-data";
+import { GlassCard } from "./glass-card";
+import { VarianceChart, FunnelChart } from "./charts";
+
+// ── VarianceCard ─────────────────────────────────────────────────────────────
+
+export function VarianceCard() {
+  return (
+    <GlassCard hue="var(--hue-variance)" title="Cash variance · 6mo" subtitle="Absolute $ by month">
+      <div style={{ display: "flex", justifyContent: "center" }}>
+        <VarianceChart data={VARIANCE_TREND} height={80} />
+      </div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginTop: 12,
+          paddingTop: 12,
+          borderTop: "1px solid var(--border-subtle)",
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontSize: 10,
+              color: "var(--text-faint)",
+              textTransform: "uppercase",
+              letterSpacing: "0.15em",
+            }}
+          >
+            Current
+          </div>
+          <div className="mono" style={{ fontSize: 16, fontWeight: 600, color: "var(--resin)" }}>
+            -$146
+          </div>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <div
+            style={{
+              fontSize: 10,
+              color: "var(--text-faint)",
+              textTransform: "uppercase",
+              letterSpacing: "0.15em",
+            }}
+          >
+            6mo avg
+          </div>
+          <div className="mono" style={{ fontSize: 16, fontWeight: 600, color: "var(--text-secondary)" }}>
+            -$234
+          </div>
+        </div>
+      </div>
+    </GlassCard>
+  );
+}
+
+// ── FilingsCard ───────────────────────────────────────────────────────────────
+
+export function FilingsCard() {
+  return (
+    <GlassCard
+      hue="var(--hue-filings)"
+      title="Upcoming filings"
+      right={
+        <a href="/dashboard/compliance" style={{ fontSize: 11, color: "var(--text-muted)", textDecoration: "none" }}>
+          All →
+        </a>
+      }
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        {FILINGS.map((f) => (
+          <div
+            key={f.form}
+            style={{
+              padding: 10,
+              background: "var(--surface-raised)",
+              border: "1px solid var(--border-subtle)",
+              borderRadius: 8,
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+              <span style={{ fontSize: 12, fontWeight: 500 }}>{f.name}</span>
+              <span
+                className="mono"
+                style={{
+                  fontSize: 10.5,
+                  color: f.daysLeft <= 10 ? "var(--resin)" : "var(--text-muted)",
+                  fontWeight: 600,
+                }}
+              >
+                {f.daysLeft}d
+              </span>
+            </div>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <span className="mono" style={{ fontSize: 10, color: "var(--text-faint)" }}>
+                {f.form} · {f.due}
+              </span>
+              {f.amount != null && (
+                <span className="mono" style={{ fontSize: 11, color: "var(--text-secondary)" }}>
+                  {fmtK(f.amount)}
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </GlassCard>
+  );
+}
+
+// ── PipelineCard ──────────────────────────────────────────────────────────────
+
+export function PipelineCard() {
+  return (
+    <GlassCard hue="var(--hue-pipeline)" title="Transaction pipeline" subtitle="842 imported this period">
+      <FunnelChart data={PIPELINE} />
+    </GlassCard>
+  );
+}
+
+// ── ActivityCard ──────────────────────────────────────────────────────────────
+
+const DOT_COLOR: Record<ActivityTag, string> = {
+  approve:  "var(--mint)",
+  alert:    "var(--resin)",
+  import:   "var(--info)",
+  evidence: "var(--accent)",
+  lock:     "var(--violet)",
+  filing:   "var(--info)",
+};
+
+export function ActivityCard() {
+  const events = ACTIVITY.slice(0, 6);
+  return (
+    <GlassCard hue="var(--hue-activity)" title="Activity pulse" subtitle="Audit trail · last hour">
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        {events.map((a, i) => (
+          <div
+            key={i}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "14px 1fr auto",
+              gap: 8,
+              padding: "8px 0",
+              borderBottom: i < events.length - 1 ? "1px solid var(--border-subtle)" : "none",
+              alignItems: "flex-start",
+            }}
+          >
+            <div style={{ paddingTop: 5 }}>
+              <span
+                className="dot-live"
+                style={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: 999,
+                  background: DOT_COLOR[a.tag],
+                  display: "block",
+                }}
+              />
+            </div>
+            <div style={{ fontSize: 11.5, lineHeight: 1.45 }}>
+              <span style={{ color: "var(--text-primary)", fontWeight: 500 }}>{a.who}</span>
+              <span style={{ color: "var(--text-muted)" }}> {a.what}</span>
+            </div>
+            <div className="mono" style={{ fontSize: 10, color: "var(--text-faint)", paddingTop: 2 }}>
+              {a.t}
+            </div>
+          </div>
+        ))}
+      </div>
+    </GlassCard>
+  );
+}

--- a/src/lib/demo/overview-data.ts
+++ b/src/lib/demo/overview-data.ts
@@ -1,0 +1,197 @@
+// Demo data for the Overview page — distilled from design prototype data.jsx
+
+export const fmtUSD = (n: number, dec = 0): string => {
+  const sign = n < 0 ? "-" : "";
+  const abs = Math.abs(n);
+  return sign + "$" + abs.toLocaleString("en-US", { minimumFractionDigits: dec, maximumFractionDigits: dec });
+};
+
+export const fmtK = (n: number): string => {
+  if (Math.abs(n) >= 1_000_000) return "$" + (n / 1_000_000).toFixed(1) + "M";
+  if (Math.abs(n) >= 1_000) return "$" + (n / 1_000).toFixed(1) + "k";
+  return fmtUSD(n);
+};
+
+export const fmtPct = (n: number, dec = 0): string => (n * 100).toFixed(dec) + "%";
+
+// ── Close period ────────────────────────────────────────────────────────────
+
+export type MilestoneStatus = "complete" | "active" | "pending";
+
+export type Milestone = {
+  label: string;
+  status: MilestoneStatus;
+  pct: number;
+};
+
+export type CloseData = {
+  period: string;
+  dayOfClose: number;
+  totalCloseDays: number;
+  percentComplete: number;
+  cpaHandoffTarget: string;
+  daysToHandoff: number;
+  milestones: Milestone[];
+};
+
+export const CLOSE_DATA: CloseData = {
+  period: "April 2026",
+  dayOfClose: 1,
+  totalCloseDays: 5,
+  percentComplete: 0.38,
+  cpaHandoffTarget: "May 6",
+  daysToHandoff: 5,
+  milestones: [
+    { label: "Intake",         status: "complete", pct: 1.0 },
+    { label: "Bank feeds",     status: "complete", pct: 1.0 },
+    { label: "Allocations",    status: "active",   pct: 0.5 },
+    { label: "Reconciliations",status: "active",   pct: 0.5 },
+    { label: "Review",         status: "pending",  pct: 0   },
+    { label: "CPA packet",     status: "pending",  pct: 0   },
+  ],
+};
+
+// ── Allocations ─────────────────────────────────────────────────────────────
+
+export type AllocationTrendPoint = { m: string; ded: number; non: number };
+
+export type AllocationsData = {
+  total: number;
+  ready: number;
+  needsSupport: number;
+  pendingController: number;
+  approved: number;
+  deductible: number;
+  nondeductible: number;
+  trend: AllocationTrendPoint[];
+};
+
+export const ALLOCATIONS: AllocationsData = {
+  total: 47,
+  ready: 18,
+  needsSupport: 9,
+  pendingController: 6,
+  approved: 14,
+  deductible: 284_614.03,
+  nondeductible: 118_470.41,
+  trend: [
+    { m: "Nov", ded: 242_100, non: 96_400  },
+    { m: "Dec", ded: 268_900, non: 102_100 },
+    { m: "Jan", ded: 251_200, non: 118_300 },
+    { m: "Feb", ded: 274_500, non: 104_200 },
+    { m: "Mar", ded: 262_800, non: 112_600 },
+    { m: "Apr", ded: 284_614, non: 118_470 },
+  ],
+};
+
+// ── Cash reconciliations ─────────────────────────────────────────────────────
+
+export type RecStatus = "balanced" | "investigating" | "exception" | "ready_to_post";
+export type RecAccountType = "drawer" | "vault" | "bank_clearing" | "bank";
+
+export type CashRec = {
+  id: string;
+  loc: string;
+  type: RecAccountType;
+  expected: number;
+  actual: number;
+  variance: number;
+  status: RecStatus;
+  owner: string;
+};
+
+export const CASH_RECS: CashRec[] = [
+  { id: "rec_001", loc: "Oakland — Front Drawer 1",    type: "drawer",        expected: 3_250.00,    actual: 3_184.00,    variance: -66,  status: "investigating",  owner: "Closing Manager"      },
+  { id: "rec_002", loc: "Oakland — Vault Cash",         type: "vault",         expected: 42_180.52,   actual: 42_180.52,   variance: 0,    status: "balanced",       owner: "General Manager"       },
+  { id: "rec_003", loc: "Oakland — Armored Clearing",   type: "bank_clearing", expected: 12_840.52,   actual: 12_760.52,   variance: -80,  status: "exception",      owner: "Staff Accountant"      },
+  { id: "rec_004", loc: "Oakland — Operating (SVB)",    type: "bank",          expected: 90_655.14,   actual: 90_655.14,   variance: 0,    status: "ready_to_post",  owner: "Assistant Controller"  },
+];
+
+// ── Action queue ─────────────────────────────────────────────────────────────
+
+export type ActionSeverity = "critical" | "high" | "normal";
+export type ActionKind = "Allocation" | "Rec" | "Filing";
+
+export type ActionItem = {
+  id: string;
+  severity: ActionSeverity;
+  kind: ActionKind;
+  title: string;
+  detail: string;
+  owner: string;
+  due: string;
+  amount: number;
+};
+
+export const ACTION_QUEUE: ActionItem[] = [
+  { id: "a1", severity: "critical", kind: "Allocation", title: "Route payroll labor variance to controller",         detail: "Richmond · $13.8k deductible · direct labor ratio moved +9 pts",        owner: "M. Chen",  due: "Today",  amount: 18_620 },
+  { id: "a2", severity: "critical", kind: "Rec",        title: "Missing armored receipt image blocks clearing",      detail: "Oakland · Armored Clearing · $80 carrier fee reclass drafted",           owner: "R. Soto",  due: "Today",  amount: -80    },
+  { id: "a3", severity: "high",     kind: "Allocation", title: "Event SKU recap missing — fallback below threshold", detail: "Community Wellness Expo · confidence 42% · $2.3k at stake",              owner: "R. Soto",  due: "May 2",  amount: 2_300  },
+  { id: "a4", severity: "high",     kind: "Filing",     title: "CA excise tax return — Q1 2026",                    detail: "CDTFA-501-CA · 9 days · $48.2k staged liability",                        owner: "A. Pierce",due: "Apr 30", amount: 48_220 },
+  { id: "a5", severity: "high",     kind: "Rec",        title: "Drawer variance — unsigned payout slip",            detail: "Oakland · Front Drawer 1 · customer return not tagged",                  owner: "J. Ramos", due: "Today",  amount: -66    },
+  { id: "a6", severity: "normal",   kind: "Filing",     title: "CA sales & use tax — April",                        detail: "CDTFA-401 · 12 days · $21.4k staged",                                    owner: "A. Pierce",due: "May 2",  amount: 21_400 },
+  { id: "a7", severity: "normal",   kind: "Allocation", title: "Approve security split — Oakland",                  detail: "Bay Alarm · 28.1% support footage · confidence 91%",                     owner: "N. Vega",  due: "May 2",  amount: 614    },
+];
+
+// ── Variance trend ────────────────────────────────────────────────────────────
+
+export type VariancePoint = { m: string; v: number };
+
+export const VARIANCE_TREND: VariancePoint[] = [
+  { m: "Nov", v: -340 },
+  { m: "Dec", v: -180 },
+  { m: "Jan", v: -420 },
+  { m: "Feb", v: -95  },
+  { m: "Mar", v: -220 },
+  { m: "Apr", v: -146 },
+];
+
+// ── Transaction pipeline ──────────────────────────────────────────────────────
+
+export type PipelineStage = { stage: string; count: number; amount: number };
+
+export const PIPELINE: PipelineStage[] = [
+  { stage: "Imported",    count: 842, amount: 312_400 },
+  { stage: "Categorized", count: 798, amount: 302_100 },
+  { stage: "Allocated",   count: 681, amount: 261_800 },
+  { stage: "Reviewed",    count: 544, amount: 214_300 },
+  { stage: "Posted",      count: 488, amount: 198_700 },
+];
+
+// ── Upcoming filings ──────────────────────────────────────────────────────────
+
+export type Filing = {
+  name: string;
+  form: string;
+  due: string;
+  daysLeft: number;
+  amount: number | null;
+  status: "staged" | "pending";
+};
+
+export const FILINGS: Filing[] = [
+  { name: "CA excise tax return",        form: "CDTFA-501-CA", due: "Apr 30", daysLeft: 9,  amount: 48_220, status: "staged"  },
+  { name: "CA sales & use tax",          form: "CDTFA-401",    due: "May 2",  daysLeft: 12, amount: 21_400, status: "staged"  },
+  { name: "Metrc monthly reconciliation",form: "METRC-MON",    due: "May 10", daysLeft: 20, amount: null,   status: "pending" },
+];
+
+// ── Activity feed ─────────────────────────────────────────────────────────────
+
+export type ActivityTag = "approve" | "alert" | "import" | "evidence" | "lock" | "filing";
+
+export type ActivityEvent = {
+  t: string;
+  who: string;
+  what: string;
+  tag: ActivityTag;
+};
+
+export const ACTIVITY: ActivityEvent[] = [
+  { t: "2 min",   who: "Controller", what: "approved allocation override · Cost of Goods — Cultivation",  tag: "approve"  },
+  { t: "8 min",   who: "System",     what: "flagged cash vault variance ($1,240) — Oakland",               tag: "alert"    },
+  { t: "15 min",  who: "Reviewer",   what: "signed off on Sacramento drawer reconciliation",               tag: "approve"  },
+  { t: "23 min",  who: "System",     what: "imported 842 transactions from Mercury bank feed",             tag: "import"   },
+  { t: "41 min",  who: "N. Vega",    what: "attached floorplan evidence · Oakland security split",         tag: "evidence" },
+  { t: "1h",      who: "Controller", what: "locked reporting period for March 2026",                       tag: "lock"     },
+  { t: "1h 12m",  who: "A. Pierce",  what: "staged CA excise liability at $48.2k",                         tag: "filing"   },
+];


### PR DESCRIPTION
## Summary

Implements the Overview page from the Claude Design export (`Overview.html`), replacing the text-heavy placeholder with a data-rich operator command center.

- **Close hero strip** — breathing mint glow (5.5s animation), 6-milestone progress bar, ring at 38%, "Resume close" + "Preview CPA packet" CTAs
- **4 KPI tiles with sparklines** — allocation queue, unreconciled cash, 280E exposure, filings due; each with section hue tint
- **280E exposure panel** — 6-month stacked bar chart (deductible vs nondeductible) + current-period breakdown sidebar
- **Cash reconciliation lane** — 4 Oakland accounts (drawer / vault / clearing / bank) with variance, status pills, owner
- **Action queue** — 7 items filterable by All / Allocation / Rec / Filing, severity indicator bars, amounts
- **Right rail** — cash variance 6-month chart, filings countdown, transaction pipeline funnel, activity pulse feed

### Aesthetic
All panels use the `.glass` class (backdrop-filter blur, inner highlight pseudo-elements, hover `translateY(-3px)` shadow bloom). Section hues (`--hue-close` through `--hue-activity`) tint each panel via `color-mix(in oklch, ...)`. Electric mint `#48C072` + warm resin amber `#F2B147`; no harsh reds.

## Test plan

- [ ] Visit `/dashboard` — confirm all panels render with correct data
- [ ] Hover over panels — confirm lift + shadow bloom animation
- [ ] Close hero should have a slow breathing green glow
- [ ] Action queue filter tabs (All / Allocation / Rec / Filing) work correctly
- [ ] Mobile: AppShell sidebar nav still toggles correctly
- [ ] `npx tsc --noEmit` — zero errors

https://claude.ai/code/session_01WcRroxG19rYHCyKmsRzHJx