### PR TITLE
fix(backup): repair CLI export, add destination preflight

### DIFF
--- a/docs/security-and-vendors.md
+++ b/docs/security-and-vendors.md
@@ -78,7 +78,22 @@ account-closure away from total loss. Nightly snapshots run to storage you own.
    ```
 4. Set `BACKUP_S3_ENDPOINT`, `BACKUP_S3_BUCKET`, `BACKUP_S3_REGION`,
    `BACKUP_S3_ACCESS_KEY_ID`, `BACKUP_S3_SECRET_ACCESS_KEY` in Vercel.
-5. `vercel.json` runs `/api/backup` daily at 07:00 UTC.
+5. **Prove the destination works before trusting it:**
+   ```bash
+   npm run backup:preflight
+   ```
+   Writes a test object, reads it back, checks the bytes match, and deletes it.
+   Run it again after rotating storage keys.
+6. `vercel.json` runs `/api/backup` daily at 07:00 UTC.
+7. Trigger one real backup and confirm `uploaded: true`:
+   ```bash
+   curl -X POST -H "Authorization: Bearer $BACKUP_SECRET" https://<your-app>/api/backup
+   ```
+
+> A misconfigured bucket does not announce itself. The nightly job fails into a
+> log nobody reads, and the first sign of trouble is finding no snapshots on the
+> day you need one. Preflight exists so that failure is loud and immediate
+> instead.
 
 **Manual snapshot**
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "backup:export": "npx tsx scripts/backup-export.ts",
     "drill:fixture": "npx tsx scripts/drill-fixture.ts",
     "backup:compare": "npx tsx scripts/compare-snapshots.ts",
-    "drill": "bash scripts/run-drill.sh"
+    "drill": "bash scripts/run-drill.sh",
+    "backup:preflight": "npx tsx scripts/backup-preflight.ts"
   },
   "dependencies": {
     "@clerk/nextjs": "^5.7.6",

--- a/scripts/backup-preflight.ts
+++ b/scripts/backup-preflight.ts
@@ -1,0 +1,127 @@
+/**
+ * Proves the backup destination actually works, before trusting it.
+ *
+ *   npm run backup:preflight
+ *
+ * Reads BACKUP_S3_* from the environment and performs a real round trip
+ * against the bucket: write an object, read it back, confirm the bytes match,
+ * then delete it. Nothing is assumed from the absence of an error.
+ *
+ * This exists because the failure mode it catches is silent. A misconfigured
+ * bucket does not announce itself — the nightly job fails into a log nobody
+ * reads, and the first sign of trouble is discovering there are no snapshots
+ * on the day you need one. Run this the moment you finish configuring
+ * storage, and again after rotating keys.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readS3TargetFromEnv, putObject, getObject, deleteObject } from "../src/lib/backup/s3";
+
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const BOLD = "\x1b[1m";
+const OFF = "\x1b[0m";
+
+function fail(message: string, hint?: string): never {
+  console.error(`\n${RED}FAIL:${OFF} ${message}`);
+  if (hint) console.error(`\n${hint}`);
+  process.exit(1);
+}
+
+async function main() {
+  console.log(`${BOLD}Backup destination preflight${OFF}\n`);
+
+  const target = readS3TargetFromEnv();
+  if (!target) {
+    fail(
+      "Storage is not configured — one or more BACKUP_S3_* variables are missing.",
+      `Set all of these in the environment you are testing:\n` +
+        `  BACKUP_S3_ENDPOINT           e.g. https://<account>.r2.cloudflarestorage.com\n` +
+        `  BACKUP_S3_BUCKET             e.g. tranquillo-green-backups\n` +
+        `  BACKUP_S3_REGION             "auto" for R2, the region name for S3\n` +
+        `  BACKUP_S3_ACCESS_KEY_ID\n` +
+        `  BACKUP_S3_SECRET_ACCESS_KEY`,
+    );
+  }
+
+  console.log(`  endpoint: ${target.endpoint}`);
+  console.log(`  bucket:   ${target.bucket}`);
+  console.log(`  region:   ${target.region}`);
+  console.log(`  key id:   ${target.accessKeyId.slice(0, 4)}…${target.accessKeyId.slice(-4)}\n`);
+
+  const key = `tranquillo-green/_preflight/${new Date().toISOString().slice(0, 10)}-${randomUUID()}.txt`;
+  const payload = `tranquillo-green preflight ${new Date().toISOString()} ${randomUUID()}`;
+
+  // 1. write
+  process.stdout.write("  1/4 writing a test object … ");
+  try {
+    await putObject(target, key, payload, "text/plain");
+  } catch (error) {
+    console.log(`${RED}failed${OFF}`);
+    fail(
+      error instanceof Error ? error.message : String(error),
+      `${YELLOW}Common causes:${OFF}\n` +
+        `  403 SignatureDoesNotMatch  — wrong secret access key, or wrong region\n` +
+        `  403 AccessDenied           — the token lacks write permission on this bucket\n` +
+        `  404 NoSuchBucket           — bucket name is wrong, or it lives in another account\n` +
+        `  ENOTFOUND / DNS failure    — endpoint URL is wrong`,
+    );
+  }
+  console.log(`${GREEN}ok${OFF}`);
+
+  // 2. read back
+  process.stdout.write("  2/4 reading it back … ");
+  let readBack: string | null;
+  try {
+    readBack = await getObject(target, key);
+  } catch (error) {
+    console.log(`${RED}failed${OFF}`);
+    fail(
+      error instanceof Error ? error.message : String(error),
+      `The write succeeded but the read did not. The token likely has write ` +
+        `permission without read — which means you could not actually recover ` +
+        `from these backups.`,
+    );
+  }
+  if (readBack === null) {
+    console.log(`${RED}failed${OFF}`);
+    fail("The object was written but came back 404 on read.");
+  }
+  console.log(`${GREEN}ok${OFF}`);
+
+  // 3. verify contents
+  process.stdout.write("  3/4 verifying the bytes match … ");
+  if (readBack !== payload) {
+    console.log(`${RED}failed${OFF}`);
+    fail(
+      `Content mismatch. Wrote ${payload.length} bytes, read back ${readBack.length}.`,
+      "Something between here and the bucket is altering objects. Do not use this destination.",
+    );
+  }
+  console.log(`${GREEN}ok${OFF}`);
+
+  // 4. clean up
+  process.stdout.write("  4/4 deleting the test object … ");
+  try {
+    await deleteObject(target, key);
+    console.log(`${GREEN}ok${OFF}`);
+  } catch (error) {
+    console.log(`${YELLOW}could not delete${OFF}`);
+    console.log(
+      `\n${YELLOW}Note:${OFF} write and read both work, so backups will function. ` +
+        `The token cannot delete, so remove this object by hand:\n  ${key}\n` +
+        `A lifecycle rule for expiring old snapshots will also need delete permission.`,
+    );
+  }
+
+  console.log(`\n${BOLD}${GREEN}PASS${OFF} — the destination accepts writes and returns them intact.\n`);
+  console.log("Next:");
+  console.log("  1. Confirm BACKUP_SECRET is set on BOTH Convex and Vercel (checked independently).");
+  console.log("  2. Trigger one real backup:");
+  console.log('       curl -X POST -H "Authorization: Bearer $BACKUP_SECRET" https://<your-app>/api/backup');
+  console.log("     It should return uploaded:true with a destination URL.");
+  console.log("  3. Download that snapshot and run: npm run backup:verify -- <file>");
+}
+
+main().catch((error) => fail(error instanceof Error ? error.message : String(error)));

--- a/src/lib/backup/run-backup.ts
+++ b/src/lib/backup/run-backup.ts
@@ -1,5 +1,6 @@
-import "server-only";
-
+// Intentionally not marked `server-only`: also imported by scripts/backup-export.ts
+// so a snapshot can be taken without the web app running — which is exactly
+// when you need one most.
 import { ConvexHttpClient } from "convex/browser";
 import { anyApi } from "convex/server";
 import { putObject, readS3TargetFromEnv } from "./s3";

--- a/src/lib/backup/s3.ts
+++ b/src/lib/backup/s3.ts
@@ -1,5 +1,7 @@
-import "server-only";
-
+// Intentionally not marked `server-only`: this module is shared by the
+// Next.js API route and by the CLI scripts (export, preflight, drill), and
+// `server-only` throws outside a Next build. Client bundling is prevented
+// naturally by the node:crypto import below.
 import { createHash, createHmac } from "node:crypto";
 
 /**
@@ -59,31 +61,37 @@ export function readS3TargetFromEnv(): S3Target | null {
  * Throws with the provider's response body when the request is rejected, so
  * a misconfigured bucket surfaces a real error rather than a silent no-op.
  */
-export async function putObject(
+async function signedRequest(
   target: S3Target,
+  method: "PUT" | "GET" | "DELETE",
   key: string,
-  body: string,
+  body?: string,
   contentType = "application/x-ndjson",
-): Promise<string> {
+): Promise<{ ok: boolean; status: number; statusText: string; text: string; url: string }> {
   const url = new URL(`${target.endpoint.replace(/\/$/, "")}/${target.bucket}/${encodeKey(key)}`);
   const host = url.host;
 
-  const payload = Buffer.from(body, "utf8");
+  const payload = body === undefined ? Buffer.alloc(0) : Buffer.from(body, "utf8");
   const payloadHash = sha256Hex(payload);
 
   const now = new Date();
   const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, ""); // YYYYMMDDTHHMMSSZ
   const dateStamp = amzDate.slice(0, 8);
 
-  const signedHeaders = "content-type;host;x-amz-content-sha256;x-amz-date";
+  // Content-Type is only signed when a body is sent; signing a header that is
+  // not transmitted produces a signature mismatch.
+  const hasBody = body !== undefined;
+  const signedHeaders = hasBody
+    ? "content-type;host;x-amz-content-sha256;x-amz-date"
+    : "host;x-amz-content-sha256;x-amz-date";
   const canonicalHeaders =
-    `content-type:${contentType}\n` +
+    (hasBody ? `content-type:${contentType}\n` : "") +
     `host:${host}\n` +
     `x-amz-content-sha256:${payloadHash}\n` +
     `x-amz-date:${amzDate}\n`;
 
   const canonicalRequest = [
-    "PUT",
+    method,
     url.pathname,
     "", // no query string
     canonicalHeaders,
@@ -105,28 +113,73 @@ export async function putObject(
   );
   const signature = createHmac("sha256", signingKey).update(stringToSign, "utf8").digest("hex");
 
-  const authorization =
-    `AWS4-HMAC-SHA256 Credential=${target.accessKeyId}/${scope}, ` +
-    `SignedHeaders=${signedHeaders}, Signature=${signature}`;
-
-  const response = await fetch(url.toString(), {
-    method: "PUT",
-    headers: {
-      "Content-Type": contentType,
-      "x-amz-content-sha256": payloadHash,
-      "x-amz-date": amzDate,
-      Authorization: authorization,
-      "Content-Length": String(payload.byteLength),
-    },
-    body: payload,
-  });
-
-  if (!response.ok) {
-    const detail = await response.text().catch(() => "");
-    throw new Error(
-      `Backup upload failed (${response.status} ${response.statusText}): ${detail.slice(0, 500)}`,
-    );
+  const headers: Record<string, string> = {
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+    Authorization:
+      `AWS4-HMAC-SHA256 Credential=${target.accessKeyId}/${scope}, ` +
+      `SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+  if (hasBody) {
+    headers["Content-Type"] = contentType;
+    headers["Content-Length"] = String(payload.byteLength);
   }
 
-  return url.toString();
+  const response = await fetch(url.toString(), {
+    method,
+    headers,
+    ...(hasBody ? { body: payload } : {}),
+  });
+
+  const text = await response.text().catch(() => "");
+  return {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    text,
+    url: url.toString(),
+  };
+}
+
+/**
+ * Uploads a single object. Returns the URL it was written to.
+ * Throws with the provider's response body when the request is rejected, so
+ * a misconfigured bucket surfaces a real error rather than a silent no-op.
+ */
+export async function putObject(
+  target: S3Target,
+  key: string,
+  body: string,
+  contentType = "application/x-ndjson",
+): Promise<string> {
+  const result = await signedRequest(target, "PUT", key, body, contentType);
+  if (!result.ok) {
+    throw new Error(
+      `Backup upload failed (${result.status} ${result.statusText}): ${result.text.slice(0, 500)}`,
+    );
+  }
+  return result.url;
+}
+
+/** Reads an object back. Returns null when it does not exist. */
+export async function getObject(target: S3Target, key: string): Promise<string | null> {
+  const result = await signedRequest(target, "GET", key);
+  if (result.status === 404) return null;
+  if (!result.ok) {
+    throw new Error(
+      `Backup read failed (${result.status} ${result.statusText}): ${result.text.slice(0, 500)}`,
+    );
+  }
+  return result.text;
+}
+
+/** Deletes an object. Succeeds whether or not it existed. */
+export async function deleteObject(target: S3Target, key: string): Promise<void> {
+  const result = await signedRequest(target, "DELETE", key);
+  // S3 returns 204 for a successful delete, and 404 is equally fine here.
+  if (!result.ok && result.status !== 404) {
+    throw new Error(
+      `Backup delete failed (${result.status} ${result.statusText}): ${result.text.slice(0, 500)}`,
+    );
+  }
 }


### PR DESCRIPTION
Found while setting up the backup bucket.

## A live bug in merged code

`src/lib/backup/s3.ts` and `run-backup.ts` imported `server-only`, which throws outside a Next build. That meant:

- **`npm run backup:export` was broken entirely** — the manual/offline snapshot path, which is exactly what you reach for when the app won't start.
- **`npm run drill` would have failed at step 6/6**, its final export.

It went unnoticed because this environment's network policy blocks Convex, so the export path was never actually executed here — only the modules that don't touch it were. Both files are intentionally dual-use (Next API route *and* CLI) and now carry a comment saying so. Client bundling is still prevented naturally by the `node:crypto` import.

## Preflight — because silent backup failure is the dangerous kind

A misconfigured bucket doesn't announce itself. The nightly job fails into a log nobody reads, and the first sign of trouble is finding no snapshots on the day you need one.

`npm run backup:preflight` proves the destination works instead of assuming it:

1. writes a test object
2. reads it back
3. compares the bytes
4. deletes it

A **write-only token fails at step 2** — deliberately, because a backup you can't read isn't a backup. Failures map to causes: `SignatureDoesNotMatch` → wrong secret or region, `AccessDenied` → permissions, `NoSuchBucket` → wrong bucket or account, DNS → wrong endpoint.

## Verifying the signing itself

The SigV4 signer is hand-written (no AWS SDK on this path), so I tested it against a server that actually validates signatures rather than one that just accepts bytes:

- correct credentials → write, read, and delete all succeed
- wrong secret → rejected with `SignatureDoesNotMatch`, surfaced with the right hint

`s3.ts` gains signed GET and DELETE through a shared signer. One subtlety worth noting: `Content-Type` is only signed when a body is actually sent — signing a header that isn't transmitted produces a signature mismatch.

## Verification

- `npm run lint` — clean
- `npx tsc --noEmit` — clean (exit 0)
- `npm test` — 16/16
- `npm run build` — 138/138 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4B9F6UMHVkzFJQK2cYn3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4B9F6UMHVkzFJQK2cYn3Z)_